### PR TITLE
Adding support for connection via ssh key

### DIFF
--- a/lib/paperclip-sftp/storage/sftp.rb
+++ b/lib/paperclip-sftp/storage/sftp.rb
@@ -28,7 +28,7 @@ module Paperclip
           @sftp_options[:user],
           password: @sftp_options[:password],
           port: @sftp_options[:port],
-          keys: [@sftp_options[:keys]]
+          keys: @sftp_options[:keys]
         )
       end
 

--- a/lib/paperclip-sftp/storage/sftp.rb
+++ b/lib/paperclip-sftp/storage/sftp.rb
@@ -26,8 +26,8 @@ module Paperclip
         @sftp ||= Net::SFTP.start(
           @sftp_options[:host],
           @sftp_options[:user],
-          password: @sftp_options[:password],
-          port: @sftp_options[:port]
+          port: @sftp_options[:port],
+          keys: [@sftp_options[:keys]]
         )
       end
 

--- a/lib/paperclip-sftp/storage/sftp.rb
+++ b/lib/paperclip-sftp/storage/sftp.rb
@@ -26,6 +26,7 @@ module Paperclip
         @sftp ||= Net::SFTP.start(
           @sftp_options[:host],
           @sftp_options[:user],
+          password: @sftp_options[:password],
           port: @sftp_options[:port],
           keys: [@sftp_options[:keys]]
         )


### PR DESCRIPTION
The change was obvious, this simple addition would offer passwordless ssh connection via private keys. Never did any pull requests before, so correct me if I'm doing anything wrong.

The conf ends up being the following :

```
has_attached_file :image,
    storage: :sftp,
    path: "{remote_path}/{image_name_rewrite_or_plain_filename}",
    sftp_options: {
      host: ENV["PAPERCLIP_HOST"],
      user: ENV["PAPERCLIP_USER"],
      port: ENV["PAPERCLIP_PORT"],
      keys: ENV["ID_RSA_FILE_PATH"]
    }
```
